### PR TITLE
feat: add routing classification in observation mode

### DIFF
--- a/slimclaw.config.json
+++ b/slimclaw.config.json
@@ -8,6 +8,19 @@
     "enabled": true,
     "minContentLength": 1000
   },
+  "routing": {
+    "enabled": true,
+    "allowDowngrade": true,
+    "minConfidence": 0.4,
+    "pinnedModels": [],
+    "tiers": {
+      "simple": "anthropic/claude-3-haiku-20240307",
+      "mid": "anthropic/claude-sonnet-4-20250514",
+      "complex": "anthropic/claude-opus-4-6",
+      "reasoning": "anthropic/claude-opus-4-6"
+    },
+    "reasoningBudget": 10000
+  },
   "dashboard": {
     "enabled": true,
     "port": 3333


### PR DESCRIPTION
## What

Enables ClawRouter classification in the `llm_input` hook so routing recommendations are visible in logs and dashboard — without mutating the actual model (observation mode only).

## Why

After merging ClawRouter integration (#2), the routing pipeline wasn't being invoked because the plugin's `llm_input` hook only tracked token metrics. The `inferenceOptimizer` middleware (which includes routing) requires active mutation hooks that OpenClaw doesn't yet support.

This bridges the gap by calling `classifyWithRouter` directly in the hook for observability.

## Changes

- **`src/index.ts`**: Call `classifyWithRouter` in `llm_input` hook, log routing recommendation (tier, confidence, model, signals), store in request metrics
- **`src/index.ts`**: Load `routing` config from `slimclaw.config.json`
- **`src/index.ts`**: Wire routing data into `SlimClawMetricsAdapter` so dashboard shows tier distribution
- **`slimclaw.config.json`**: Add routing config (enabled, tiers, minConfidence)

## Closes

- Closes #3 (reasoning tier already present in both Zod schema and DEFAULT_CONFIG)

## Verify

After loading, each LLM request logs:
```
[SlimClaw] 🔀 Routing recommendation: simple tier (confidence: 0.85) → anthropic/claude-3-haiku-20240307 | signals: [router:primary, high-confidence]
```

Dashboard at `localhost:3333/api/routing-stats` shows tier distribution.

---

<!-- gitsniff-summary-start -->
## 🐕 GitSniff Summary

### What this PR does

This change enhances the SlimClaw plugin by enabling ClawRouter classification during the `llm_input` hook. This allows the system to generate and track routing recommendations, including tier, confidence, and model suggestions, which are then logged and made visible in the dashboard for analysis, providing valuable insights into potential routing decisions without actively changing the model.

### Key Changes

- Integrated `classifyWithRouter` into the `llm_input` hook for routing recommendations.
- Added routing configuration to `slimclaw.config.json` for custom tier definitions.
- Updated `RequestMetric` and `SlimClawMetricsAdapter` to store and display routing data in the dashboard.
- Implemented logging of routing recommendations, including tier, confidence, model, and signals.

### Review Score: Excellent 🟢

> [!TIP]
> No major issues found. Safe to merge.

<a href="https://www.gitsniff.ai/dashboard/pull-requests/dc4657b1-60b5-4467-91a1-ccbf2931bec4" target="_blank"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.gitsniff.ai/open-in-dashboard-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.gitsniff.ai/open-in-dashboard-light.svg"><img alt="Open in Dashboard" src="https://www.gitsniff.ai/open-in-dashboard.svg"></picture></a>

<sub>🐕 Reviewed by <a href="https://www.gitsniff.ai" target="_blank">GitSniff</a></sub>
<!-- gitsniff-summary-end -->