### PR TITLE
fix: exclude system prompt from routing classification

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -344,11 +344,9 @@ const slimclawPlugin = {
             // Only classify the CURRENT request intent, not the full history.
             // Full history causes everything to be "reasoning/lengthy-content".
             // Include: system prompt (for context) + last 3 messages (conversational flow) + current prompt.
+            // Classify based on user intent only — exclude system prompt
+            // (system prompt is static context, not indicative of request complexity)
             const classificationMessages: Message[] = [];
-            
-            if (systemPrompt) {
-              classificationMessages.push({ role: 'system', content: systemPrompt });
-            }
             
             // Last few messages for conversational context
             const history = (historyMessages as any[]) || [];


### PR DESCRIPTION
## Problem

Every message — even a simple "oi" — was being classified as `reasoning` tier with `lengthy-content` signal. The routing classifier was including the **system prompt** (~15k+ chars of AGENTS.md, SOUL.md, USER.md, TOOLS.md) in the classification input, which always triggered the `text.length > 1000` threshold.

## Fix

Exclude system prompt from classification messages. The system prompt is static context that doesn't indicate request complexity — only user messages and recent history should determine routing tier.

## Before
```
User: "oi"
🔀 reasoning tier (0.83) → opus | signals: [lengthy-content, high-confidence]
```

## After  
```
User: "oi"
🔀 simple tier → haiku
```

## Files Changed
- `src/index.ts` — removed `systemPrompt` from classification messages

---

<!-- gitsniff-summary-start -->
## 🐕 GitSniff Summary

### What this PR does

This change enhances the accuracy of the SlimClaw plugin's routing classification by preventing the system prompt from influencing the classification of user requests. By excluding the static system prompt, the classifier can more accurately determine the complexity and intent of actual user messages, leading to more appropriate model routing decisions and token optimization. This correction ensures that small, simple user prompts are correctly identified as such, rather than being misclassified due to a lengthy system prompt.

### Key Changes

- Removed the system prompt from the `classificationMessages` array in `llm_input` hook.
- Added comments explaining the rationale for excluding the system prompt from classification.
- Ensured routing classification focuses solely on user messages and recent conversational history.
- Corrected the issue where all messages were being classified as `reasoning` tier with `lengthy-content` signal due to large system prompts.

### Review Score: Excellent 🟢

> [!TIP]
> No major issues found. Safe to merge.

<a href="https://www.gitsniff.ai/dashboard/pull-requests/eaca1add-0884-494b-a9db-27b5407e7476" target="_blank"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.gitsniff.ai/open-in-dashboard-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.gitsniff.ai/open-in-dashboard-light.svg"><img alt="Open in Dashboard" src="https://www.gitsniff.ai/open-in-dashboard.svg"></picture></a>

<sub>🐕 Reviewed by <a href="https://www.gitsniff.ai" target="_blank">GitSniff</a></sub>
<!-- gitsniff-summary-end -->