### PR TITLE
fix: wire routingTier into dashboard tier distribution

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -208,9 +208,13 @@ class SlimClawMetricsAdapter implements Pick<MetricsCollector, 'getAll' | 'getRe
     summarizationMethod: 'none' as const,
     classificationTier: request.routingTier ?? 'complex',
     classificationConfidence: request.routingConfidence ?? 1,
-    classificationScores: { simple: 0, mid: 0, complex: 1, reasoning: 0 },
+    classificationScores: request.routingTier 
+      ? { simple: 0, mid: 0, complex: 0, reasoning: 0, [request.routingTier]: request.routingConfidence ?? 1 }
+      : { simple: 0, mid: 0, complex: 1, reasoning: 0 },
     classificationSignals: request.routingSignals || [],
     routingApplied: !!request.routingTier,
+    ...(request.routingTier ? { routingTier: request.routingTier } : {}),
+    ...(request.routingConfidence != null ? { routingConfidence: request.routingConfidence } : {}),
     targetModel: request.routingModel || request.model,
     modelDowngraded: !!(request.routingModel && request.routingModel !== request.model),
     modelUpgraded: false,


### PR DESCRIPTION
## Problem

Dashboard `/api/routing-stats` showed `tierDistribution: { simple: 0, mid: 0, complex: 0, reasoning: 0 }` even when routing was active and classifying requests.

## Root Cause

The `SlimClawMetricsAdapter.convertToOptimizerMetrics` was setting `classificationTier` but **not** `routingTier`. The `/api/routing-stats` endpoint filters by `m.routingTier`, not `m.classificationTier`.

## Fix

- Set `routingTier` and `routingConfidence` in the adapter (using spread to handle `exactOptionalPropertyTypes`)
- Generate `classificationScores` from actual routing result instead of hardcoded `complex: 1`

## Before
```json
{ "tierDistribution": { "simple": 0, "mid": 0, "complex": 0, "reasoning": 0 } }
```

## After
```json
{ "tierDistribution": { "simple": 0, "mid": 100, "complex": 0, "reasoning": 0 } }
```

---

<!-- gitsniff-summary-start -->
## 🐕 GitSniff Summary

### What this PR does

This pull request rectifies an issue in the SlimClaw dashboard where routing tier distribution metrics were incorrectly showing zero values, even when routing was actively classifying requests. By ensuring the correct population of `routingTier` and `routingConfidence` within the `SlimClawMetricsAdapter` and dynamically generating `classificationScores` based on the actual routing result, the dashboard will now accurately reflect the distribution of requests across different routing tiers. This improves the observability and reliability of the SlimClaw's routing optimization features for users.

### Key Changes

- Set `routingTier` and `routingConfidence` in the `SlimClawMetricsAdapter` when `request.routingTier` is available.
- Dynamically generate `classificationScores` based on the actual `request.routingTier` and `request.routingConfidence`.
- Ensure the dashboard's `/api/routing-stats` endpoint correctly displays tier distribution.
- Resolve the discrepancy between `classificationTier` and `routingTier` usage in metrics reporting.

### Review Score: Excellent 🟢

> [!TIP]
> No major issues found. Safe to merge.

<a href="https://www.gitsniff.ai/dashboard/pull-requests/9b2ed99e-b10a-4ff4-ac81-7fd6a55312a1" target="_blank"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.gitsniff.ai/open-in-dashboard-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.gitsniff.ai/open-in-dashboard-light.svg"><img alt="Open in Dashboard" src="https://www.gitsniff.ai/open-in-dashboard.svg"></picture></a>

<sub>🐕 Reviewed by <a href="https://www.gitsniff.ai" target="_blank">GitSniff</a></sub>
<!-- gitsniff-summary-end -->